### PR TITLE
Use yaml.safeLoad instead of load

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -15,7 +15,7 @@ class Settings {
   constructor(github, repo, config) {
     this.github = github;
     this.repo = repo;
-    this.config = yaml.load(config);
+    this.config = yaml.safeLoad(config);
   }
 
   update() {


### PR DESCRIPTION
Fixes issue where untrusted yaml file could contain JavaScript: https://github.com/nodeca/js-yaml#safeload-string---options-