### PR TITLE
Add Guidance on How to Preserve Permission Levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,6 @@ teams:
 
 **WARNING:** Note that this app inherently _escalates anyone with `push` permissions to the **admin** role_, since they can push config settings to the `master` branch, which will be synced. In a future, we may add restrictions to allow changes to the config file to be merged only by specific people/teams, or those with **admin** access _(via a combination of protected branches, required statuses, and branch restrictions)_. Until then, use caution when merging PRs and adding collaborators.
 
+Until restrictions are added in this app, one way to preserve admin/push permissions is to untilize the [GitHub CodeOwners feature](https://help.github.com/articles/about-codeowners/) to set one or more administrative users as the code owner of the `.github/settings.yml` file, and turn on "require code owner review" for the master branch. This does have the side effect of requiring code owner review for the entire branch, but helps preserve permission levels.
+
 See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this plugin.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,6 @@ teams:
 
 **WARNING:** Note that this app inherently _escalates anyone with `push` permissions to the **admin** role_, since they can push config settings to the `master` branch, which will be synced. In a future, we may add restrictions to allow changes to the config file to be merged only by specific people/teams, or those with **admin** access _(via a combination of protected branches, required statuses, and branch restrictions)_. Until then, use caution when merging PRs and adding collaborators.
 
-Until restrictions are added in this app, one way to preserve admin/push permissions is to untilize the [GitHub CodeOwners feature](https://help.github.com/articles/about-codeowners/) to set one or more administrative users as the code owner of the `.github/settings.yml` file, and turn on "require code owner review" for the master branch. This does have the side effect of requiring code owner review for the entire branch, but helps preserve permission levels.
+Until restrictions are added in this app, one way to preserve admin/push permissions is to utilize the [GitHub CodeOwners feature](https://help.github.com/articles/about-codeowners/) to set one or more administrative users as the code owner of the `.github/settings.yml` file, and turn on "require code owner review" for the master branch. This does have the side effect of requiring code owner review for the entire branch, but helps preserve permission levels.
 
 See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this plugin.


### PR DESCRIPTION
Add information/suggestion to users to use the GitHub CodeOwners feature to preserve permissions until in-app restrictions are implemented

Address issue #64 