### PR TITLE
Add support for probot-config

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const payload = context.payload
     const defaultBranch = payload.ref === 'refs/heads/' + payload.repository.default_branch
 
-    const config = getConfig(context, 'settings.yml')
-    console.log(config)
+    const config = await getConfig(context, 'settings.yml')
 
     const settingsModified = payload.commits.find(commit => {
       return commit.added.includes(Settings.FILE_NAME) ||

--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
+const getConfig = require('probot-config')
+
 module.exports = (robot, _, Settings = require('./lib/settings')) => {
   robot.on('push', async context => {
     const payload = context.payload
     const defaultBranch = payload.ref === 'refs/heads/' + payload.repository.default_branch
+
+    const config = getConfig(context, 'settings.yml')
+    console.log(config)
 
     const settingsModified = payload.commits.find(commit => {
       return commit.added.includes(Settings.FILE_NAME) ||
@@ -9,7 +14,7 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     })
 
     if (defaultBranch && settingsModified) {
-      return Settings.sync(context.github, context.repo())
+      return Settings.sync(context.github, context.repo(), config)
     }
   })
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 module.exports = (robot, _, Settings = require('./lib/settings')) => {
-  robot.on('push', receive)
-
-  async function receive (context) {
+  robot.on('push', async context => {
     const payload = context.payload
     const defaultBranch = payload.ref === 'refs/heads/' + payload.repository.default_branch
 
@@ -13,5 +11,5 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     if (defaultBranch && settingsModified) {
       return Settings.sync(context.github, context.repo())
     }
-  }
+  })
 }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,21 +1,18 @@
-const yaml = require('js-yaml')
-
 class Settings {
-  static sync (github, repo) {
+  static sync (github, repo, config) {
     return github.repos.getContent({
       owner: repo.owner,
       repo: repo.repo,
       path: Settings.FILE_NAME
     }).then(res => {
-      const content = Buffer.from(res.data.content, 'base64').toString()
-      return new Settings(github, repo, content).update()
+      return new Settings(github, repo, config).update()
     })
   }
 
   constructor (github, repo, config) {
     this.github = github
     this.repo = repo
-    this.config = yaml.safeLoad(config)
+    this.config = config
   }
 
   update () {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "license": "ISC",
   "dependencies": {
     "js-yaml": "^3.7.0",
-    "probot": "^6.0.0"
+    "probot": "^6.0.0",
+    "probot-config": "^0.1.0"
   },
   "devDependencies": {
     "jest": "^22.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,13 +2,16 @@ const {createRobot} = require('probot')
 const plugin = require('../index')
 
 describe('plugin', () => {
-  let robot
-  let event
-  let sync
+  let robot, event, sync, github
 
   beforeEach(() => {
     robot = createRobot()
-    robot.auth = () => Promise.resolve({})
+    github = {
+      repos: {
+        getContent: jest.fn(() => Promise.resolve({ data: { content: '' } }))
+      }
+    }
+    robot.auth = () => Promise.resolve(github)
 
     event = {
       event: 'push',


### PR DESCRIPTION
This PR fixes #89 and implements support for [probot/config](https://github.com/probot/probot-config)

I have also reformatted `robot.on` within `index.js` to use an arrow function, as per most other probot apps. I've started playing around with changing the `module.exports` statement to be more in line with other probot apps by doing something like:

```js
const getConfig = require('probot-config')
const Settings = require('./lib/settings')

module.exports = robot => {
  robot.on('push', async context => {
    
  <rest_of_function>

  })
}
```

but that started causing test failures I have not yet diagnosed. If that's something that makes sense to add to this PR I'm happy to dig in a bit more.