### PR TITLE
Disabled required_approving_review_count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ branches:
     protection:
       # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
       required_pull_request_reviews:
+        # NOTE: The APIs needed for the review count is currently in preview
+        # Uncommenting `required_approving_review_count` will stop the bot from working
         # The number of approvals required. (1-6)
-        required_approving_review_count: 1
+        # required_approving_review_count: 1
         # Dismiss approved reviews automatically when a new commit is pushed.
         dismiss_stale_reviews: true
         # Blocks merge until code owners have reviewed.


### PR DESCRIPTION
Commented out `required_approving_review_count` and added a comment on it. The API is currently in preview for this, and thus breaks setting branch protections.

I wasn't sure if I should remove it entirely or comment it out given the comment about the teams above. If it makes more sense to remove it instead, I'm happy to change it.