### PR TITLE
WIP: Sync settings from GitHub

### DIFF
--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -6,6 +6,18 @@ module.exports = class Repository {
     delete this.settings.topics
   }
 
+  async read () {
+    const { owner, repo } = this.settings
+
+    return (await this.github.repos.get({
+      owner,
+      repo,
+      headers: {
+        accept: 'application/vnd.github.mercy-preview+json'
+      }
+    })).data
+  }
+
   sync () {
     this.settings.name = this.settings.name || this.settings.repo
     return this.github.repos.edit(this.settings).then(() => {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -24,6 +24,22 @@ class Settings {
       return new Plugin(this.github, this.repo, config).sync()
     }))
   }
+
+  async read () {
+    const configs = await Promise.all(Object.keys(Settings.PLUGINS).map(async (section) => {
+      const Plugin = Settings.PLUGINS[section]
+      const plugin = new Plugin(this.github, this.repo)
+      console.log('reading config for ', section, this.repo, plugin.read)
+      if (!plugin.read) { return {} }
+
+      const config = {}
+      config[section] = await plugin.read()
+      return config
+    }))
+
+    // merge all the configs together
+    return Object.assign(...configs)
+  }
 }
 
 Settings.FILE_NAME = '.github/settings.yml'


### PR DESCRIPTION
This is a _very_ early work in progress to support syncing settings from GitHub. I likely wont have time to work on this any time soon, but wanted to get a PR open with some hacking I did a few days ago.

- [ ] Add a `read` method to fetch current settings for each repository
- [ ] Since each GitHub API response returns a lot of other data, use [octokit/routes](https://github.com/octokit/routes) to determine which values from the response should be saved in the config file
- [ ] Use [probot-scheduler](https://github.com/probot/scheduler) to poll for updated settings for each repository (since there are no webhooks fired for most settings changes)
- [ ] Open a Pull Request whenever settings have changed
- [ ] Open a Pull Request with initial values when the app is installed

Fixes #1
Fixes #41 
