### PR TITLE
feat: Simplify disabling portions of Branch Protection

### DIFF
--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -17,7 +17,11 @@ module.exports = class Branches {
           if (this.isEmpty(branch.protection)) {
             this.github.repos.removeBranchProtection(params)
           } else {
-            Object.assign(params, branch.protection, { headers: previewHeaders })
+            Object.assign(
+              params,
+              this.coerceProtectionOptions(branch.protection),
+              { headers: previewHeaders }
+            )
             this.github.repos.updateBranchProtection(params)
           }
         })
@@ -26,5 +30,24 @@ module.exports = class Branches {
 
   isEmpty (maybeEmpty) {
     return (maybeEmpty === null) || Object.keys(maybeEmpty).length === 0
+  }
+
+  coerceProtectionOptions (options) {
+    if (
+      (typeof options.restrictions !== 'undefined') &&
+      this.isEmpty(options.restrictions)
+    ) {
+      options.restrictions = null
+    }
+
+    if (
+      (typeof options.required_pull_request_reviews === 'object') &&
+      (typeof options.required_pull_request_reviews.dismissal_restrictions !== 'undefined') &&
+      this.isEmpty(options.required_pull_request_reviews.dismissal_restrictions)
+    ) {
+      options.required_pull_request_reviews.dismissal_restrictions = {}
+    }
+
+    return options
   }
 }

--- a/test/lib/plugins/branches.test.js
+++ b/test/lib/plugins/branches.test.js
@@ -176,5 +176,89 @@ describe('Branches', () => {
         })
       })
     })
+
+    describe('when the "dismissal_restrictions" config is null', () => {
+      it('is passed as an empty objecct', () => {
+        const plugin = configure(
+          [{
+            name: 'master',
+            protection: { required_pull_request_reviews: { dismissal_restrictions: null } }
+          }]
+        )
+
+        return plugin.sync().then(() => {
+          expect(github.repos.updateBranchProtection).toHaveBeenCalledWith({
+            owner: 'bkeepers',
+            repo: 'test',
+            branch: 'master',
+            required_pull_request_reviews: { dismissal_restrictions: {} },
+            headers: { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
+          })
+        })
+      })
+    })
+
+    describe('when the "dismissal_restrictions" config is an empty object', () => {
+      it('is passed as an empty object', () => {
+        const plugin = configure(
+          [{
+            name: 'master',
+            protection: { required_pull_request_reviews: { dismissal_restrictions: {} } }
+          }]
+        )
+
+        return plugin.sync().then(() => {
+          expect(github.repos.updateBranchProtection).toHaveBeenCalledWith({
+            owner: 'bkeepers',
+            repo: 'test',
+            branch: 'master',
+            required_pull_request_reviews: { dismissal_restrictions: {} },
+            headers: { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
+          })
+        })
+      })
+    })
+
+    describe('when the "restrictions" config is an empty object', () => {
+      it('is passed as null', () => {
+        const plugin = configure(
+          [{
+            name: 'master',
+            protection: { restrictions: {} }
+          }]
+        )
+
+        return plugin.sync().then(() => {
+          expect(github.repos.updateBranchProtection).toHaveBeenCalledWith({
+            owner: 'bkeepers',
+            repo: 'test',
+            branch: 'master',
+            restrictions: null,
+            headers: { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
+          })
+        })
+      })
+    })
+
+    describe('when the "restrictions" config is null', () => {
+      it('is passed as null', () => {
+        const plugin = configure(
+          [{
+            name: 'master',
+            protection: { restrictions: null }
+          }]
+        )
+
+        return plugin.sync().then(() => {
+          expect(github.repos.updateBranchProtection).toHaveBeenCalledWith({
+            owner: 'bkeepers',
+            repo: 'test',
+            branch: 'master',
+            restrictions: null,
+            headers: { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
+          })
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
It is unfortunate that protection.restrictions and
protection.required_pull_request_reviews.dissmisal_restrictions do not
behave the same way in the service. This change allows them to both be
treated similarly, while being set appropriately behind the scenese.