### PR TITLE
Update repository config on all default branch commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,15 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     const payload = context.payload
     const defaultBranch = payload.ref === 'refs/heads/' + payload.repository.default_branch
 
-    const config = await getConfig(context, 'settings.yml', {}, { arrayMerge: mergeArrayByName })
+    if (!defaultBranch) {
+      // Not the defualt branch, nothing to see here!
+      return;
+    }
 
-    const settingsModified = payload.commits.find(commit => {
-      return commit.added.includes(Settings.FILE_NAME) ||
-        commit.modified.includes(Settings.FILE_NAME)
+    const config = await getConfig(context, '/settings.yml', {}, {
+      arrayMerge: mergeArrayByName
     })
 
-    if (defaultBranch && settingsModified) {
-      return Settings.sync(context.github, context.repo(), config)
-    }
+    return Settings.sync(context.github, context.repo(), config)
   })
 }


### PR DESCRIPTION
This changes the behavior of the bot to update the repo config on all commits
We want our `org/.github/.github/settings.yml` to apply to all repos by default, by filtering on only commits that update the `.github/settings.yml` files we are unable to do so.

#### Current behavior
- To trigger an update of the config, we need to "modify" or fake a modification of the `.github/settings.yml`
- Repos do NOT inherit by default from `org/.github` repo (as probot-config suggests for opt-in/opt-out scenarios)

#### Desired behavior
- Any push to the default branch triggers the bot settings update
- Inherit by default from `org/.github` repository

##### Notes
The `org/.github` repository config should NOT include the following sections
```
  name: repo-name
  description: description of repo
  homepage: https://example.github.io/
  topics: github, probot
```
Maybe we could even filter them on the bot

##### Related
- #95 
