### PR TITLE
Remove potential error from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ repository:
 labels:
   - name: bug
     color: CC0000
-    description: An issue with the system 🐛.
+    description: An issue with the system.
     
   - name: feature
     color: 336699


### PR DESCRIPTION
Github API fires error `contains unicode characters above 0xffff` emoji in example

-----
[View rendered README.md](https://github.com/omrilotan/settings/blob/2019-05-07-label-error/README.md)