### PR TITLE
Add probot schedule extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
+const createScheduler = require('probot-scheduler')
 const getConfig = require('probot-config')
 const mergeArrayByName = require('./lib/mergeArrayByName')
 
 module.exports = (robot, _, Settings = require('./lib/settings')) => {
+  createScheduler(robot)
   robot.on('push', async context => {
     const payload = context.payload
     const defaultBranch = payload.ref === 'refs/heads/' + payload.repository.default_branch
@@ -16,5 +18,11 @@ module.exports = (robot, _, Settings = require('./lib/settings')) => {
     if (defaultBranch && settingsModified) {
       return Settings.sync(context.github, context.repo(), config)
     }
+  })
+
+  robot.on('schedule.repository', async context => {
+    const config = await getConfig(context, 'settings.yml', {}, { arrayMerge: mergeArrayByName })
+
+    return Settings.sync(context.github, context.repo(), config)
   })
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "deepmerge": "^2.2.1",
     "js-yaml": "^3.12.0",
     "probot": "^7.4.0",
-    "probot-config": "^1.0.0"
+    "probot-config": "^1.0.0",
+    "probot-scheduler": "^1.2.0"
   },
   "devDependencies": {
     "jest": "^22.4.4",


### PR DESCRIPTION
### Description

#### What does this pull request accomplish

Adds https://github.com/probot/scheduler to the probot-settings bot to ensure settings are synced to any dependent repo every hour.

#### What does this fix

n/a