### PR TITLE
Added preview 'mercy'

### DIFF
--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -13,7 +13,10 @@ module.exports = class Repository {
         return this.github.repos.replaceTopics({
           owner: this.settings.owner,
           repo: this.settings.repo,
-          names: this.topics.split(/\s*,\s*/)
+          names: this.topics.split(/\s*,\s*/),
+          mediaType: {
+            previews: ['mercy']
+          }
         })
       }
     })

--- a/test/lib/plugins/repository.test.js
+++ b/test/lib/plugins/repository.test.js
@@ -55,7 +55,10 @@ describe('Repository', () => {
         expect(github.repos.replaceTopics).toHaveBeenCalledWith({
           owner: 'bkeepers',
           repo: 'test',
-          names: ['foo', 'bar']
+          names: ['foo', 'bar'],
+          mediaType: {
+            previews: ['mercy']
+          }
         })
       })
     })


### PR DESCRIPTION
To access the `topics` property for repositories the `Accept` header must contain a custom media type referencing the `mercy-preview`.