### PR TITLE
Move note on branch protection to a callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ labels:
   - name: bug
     color: CC0000
     description: An issue with the system 🐛.
-    
+
   - name: feature
     color: 336699
     description: New functionality.
-    
+
   - name: first-timers-only
     # include the old name to rename an existing label
     oldname: Help Wanted
@@ -131,26 +131,13 @@ branches:
         teams: []
 ```
 
-Note: each top-level element under branch protection must be filled (eg: `required_pull_request_reviews`, `required_status_checks`, `enforce_admins` and `restrictions`). If you don't want to use one of them you should set it to `null`. Otherwise, none of the settings will be applied. For example:
-
-```yml
-branches:
-  - name: master
-    protection:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_status_checks: null
-      enforce_admins: null
-      restrictions: null
-```
-
-
+> **Note**: each top-level element under branch protection must be filled (eg: `required_pull_request_reviews`, `required_status_checks`, `enforce_admins` and `restrictions`). If you don't want to use one of them you must set it to `null` (see comments in the example above). Otherwise, none of the settings will be applied.
 
 ### Inheritance
 
 This app uses [probot-config](https://github.com/probot/probot-config). This means you can inherit settings from another repo, and only override what you want to change.
 
-Individual settings in the arrays listed under `labels`, `teams` (once it is supported) and `branches` will be merged with the base repo if the `name` of an element in the array matches the `name` of an element in the corresponding array in the base repo. A possible future enhancement would be to make that work for the other settings arrays based on `username`, or `title`. This is not currently supported. 
+Individual settings in the arrays listed under `labels`, `teams` (once it is supported) and `branches` will be merged with the base repo if the `name` of an element in the array matches the `name` of an element in the corresponding array in the base repo. A possible future enhancement would be to make that work for the other settings arrays based on `username`, or `title`. This is not currently supported.
 
 To further clarify: Inheritance within the Protected Branches plugin allows you to override specific settings per branch. For example, your `.github` repo may set default protection on the `master` branch. You can then include `master` in your `branches` array, and only override the `required_approving_review_count`.
 Alternatively, you might only have a branch like `develop` in your `branches` array, and would still get `master` protection from your base repo.


### PR DESCRIPTION
* Also remove the previous example. It was redundant                                                                                                
* Points back to the main config example   

The sentence "Otherwise, none of the settings will be applied" is important because it's not obvious that the whole settings will be silently ignored. 

Relates to #151

-----
[View rendered README.md](https://github.com/renatocaval/settings/blob/fix-branch-protection-take2/README.md)