### PR TITLE
Fixed getMilestones errors and updated api fields

### DIFF
--- a/lib/plugins/milestones.js
+++ b/lib/plugins/milestones.js
@@ -14,8 +14,8 @@ module.exports = class Milestones extends Diffable {
   }
 
   async find () {
-    const res = await this.github.issues.getMilestones(Object.assign({ state: 'all' }, this.repo))
-    return res.data
+    const options = this.github.issues.listMilestonesForRepo.endpoint.merge(Object.assign({ state: 'all' }, this.repo))
+    return this.github.paginate(options)
   }
 
   comparator (existing, attrs) {
@@ -27,7 +27,7 @@ module.exports = class Milestones extends Diffable {
   }
 
   update (existing, attrs) {
-    return this.github.issues.updateMilestone(Object.assign({ number: existing.number }, attrs, this.repo))
+    return this.github.issues.updateMilestone(Object.assign({ milestone_number: existing.number }, attrs, this.repo))
   }
 
   add (attrs) {
@@ -36,7 +36,7 @@ module.exports = class Milestones extends Diffable {
 
   remove (existing) {
     return this.github.issues.deleteMilestone(
-      Object.assign({ number: existing.number }, this.repo)
+      Object.assign({ milestone_number: existing.number }, this.repo)
     )
   }
 }

--- a/lib/plugins/milestones.js
+++ b/lib/plugins/milestones.js
@@ -13,7 +13,7 @@ module.exports = class Milestones extends Diffable {
     }
   }
 
-  async find () {
+  find () {
     const options = this.github.issues.listMilestonesForRepo.endpoint.merge(Object.assign({ state: 'all' }, this.repo))
     return this.github.paginate(options)
   }

--- a/test/lib/plugins/milestones.test.js
+++ b/test/lib/plugins/milestones.test.js
@@ -9,8 +9,13 @@ describe('Milestones', () => {
 
   beforeEach(() => {
     github = {
+      paginate: jest.fn().mockImplementation(() => Promise.resolve()),
       issues: {
-        getMilestones: jest.fn().mockImplementation(() => Promise.resolve([])),
+        listMilestonesForRepo: {
+          endpoint: {
+            merge: jest.fn().mockImplementation(() => {})
+          }
+        },
         createMilestone: jest.fn().mockImplementation(() => Promise.resolve()),
         deleteMilestone: jest.fn().mockImplementation(() => Promise.resolve()),
         updateMilestone: jest.fn().mockImplementation(() => Promise.resolve())
@@ -20,12 +25,12 @@ describe('Milestones', () => {
 
   describe('sync', () => {
     it('syncs milestones', async () => {
-      github.issues.getMilestones.mockReturnValueOnce(Promise.resolve({ data: [
+      github.paginate.mockReturnValueOnce(Promise.resolve([
         { title: 'no-change', description: 'no-change-description', due_on: null, state: 'open', number: 5 },
         { title: 'new-description', description: 'old-description', due_on: null, state: 'open', number: 2 },
         { title: 'new-state', description: 'FF0000', due_on: null, state: 'open', number: 4 },
         { title: 'remove-milestone', description: 'old-description', due_on: null, state: 'open', number: 1 }
-      ] }))
+      ]))
 
       const plugin = configure([
         { title: 'no-change', description: 'no-change-description', due_on: '2019-03-29T07:00:00Z', state: 'open' },
@@ -39,7 +44,7 @@ describe('Milestones', () => {
       expect(github.issues.deleteMilestone).toHaveBeenCalledWith({
         owner: 'bkeepers',
         repo: 'test',
-        number: 1
+        milestone_number: 1
       })
 
       expect(github.issues.createMilestone).toHaveBeenCalledWith({
@@ -53,7 +58,7 @@ describe('Milestones', () => {
         repo: 'test',
         title: 'new-description',
         description: 'modified-description',
-        number: 2
+        milestone_number: 2
       })
 
       expect(github.issues.updateMilestone).toHaveBeenCalledWith({
@@ -61,7 +66,7 @@ describe('Milestones', () => {
         repo: 'test',
         title: 'new-state',
         state: 'closed',
-        number: 4
+        milestone_number: 4
       })
 
       expect(github.issues.deleteMilestone).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Changes:
- converted getMilestones call to use listMilestonesForRepo
- added paginated results for edge cases where there are more than 100 milestones
- updated the api calls to use "milestone_number" instead of "number" field to adhere to the octokit/rest.js [documentation](https://octokit.github.io/rest.js/#octokit-routes-issues-update-milestone)

Issues:
fixes https://github.com/probot/settings/issues/153