### PR TITLE
Fixing teams plugin bug with incorrect field names

### DIFF
--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -37,8 +37,8 @@ module.exports = class Teams extends Diffable {
 
   toParams (existing, attrs) {
     return {
-      id: existing.id,
-      org: this.repo.owner,
+      team_id: existing.id,
+      owner: this.repo.owner,
       repo: this.repo.repo,
       permission: attrs.permission
     }

--- a/test/lib/plugins/teams.test.js
+++ b/test/lib/plugins/teams.test.js
@@ -36,16 +36,16 @@ describe('Teams', () => {
 
       return plugin.sync().then(() => {
         expect(github.teams.addOrUpdateRepo).toHaveBeenCalledWith({
-          org: 'bkeepers',
+          owner: 'bkeepers',
           repo: 'test',
-          id: 3,
+          team_id: 3,
           permission: 'admin'
         })
 
         expect(github.teams.addOrUpdateRepo).toHaveBeenCalledWith({
-          org: 'bkeepers',
+          owner: 'bkeepers',
           repo: 'test',
-          id: 4,
+          team_id: 4,
           permission: 'pull'
         })
 


### PR DESCRIPTION
Changes:
- corrected field names `id` to `team_id` and `org` to `owner`

Fixes #160 