### PR TITLE
specified per_page to be 100 in milestones pagination

### DIFF
--- a/lib/plugins/milestones.js
+++ b/lib/plugins/milestones.js
@@ -14,7 +14,7 @@ module.exports = class Milestones extends Diffable {
   }
 
   find () {
-    const options = this.github.issues.listMilestonesForRepo.endpoint.merge(Object.assign({ state: 'all' }, this.repo))
+    const options = this.github.issues.listMilestonesForRepo.endpoint.merge(Object.assign({ per_page: 100, state: 'all' }, this.repo))
     return this.github.paginate(options)
   }
 


### PR DESCRIPTION
Changes:
- set per_page value to 100, to reduce the number of requests made while paginating.

I forgot to do this in #156 and realized this when doing the pagination for labels at #168. Also, the default per_page value is different among requests stated [here](https://developer.github.com/v3/guides/traversing-with-pagination/#basics-of-pagination). 