### PR TITLE
Fixing pagination in teams plugin

### DIFF
--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -22,7 +22,8 @@ module.exports = class Teams extends Diffable {
   add (attrs) {
     // There is not a way to resolve a team slug to an id without fetching all
     // teams for an organization.
-    return this.allTeams.then(teams => {
+    const options = this.github.teams.list.endpoint.merge({ per_page: 100, org: this.repo.owner })
+    this.github.paginate(options).then(teams => {
       const existing = teams.find(team => this.comparator(team, attrs))
 
       return this.github.teams.addOrUpdateRepo(this.toParams(existing, attrs))
@@ -41,31 +42,6 @@ module.exports = class Teams extends Diffable {
       owner: this.repo.owner,
       repo: this.repo.repo,
       permission: attrs.permission
-    }
-  }
-
-  // Lazy getter to fetch all teams for the organization
-  get allTeams () {
-    const getter = this.github.teams.list({ org: this.repo.owner })
-      .then(this.paginate.bind(this))
-      .then(responses => {
-        return responses.reduce((teams, res) => {
-          return teams.concat(res.data)
-        }, [])
-      })
-    Object.defineProperty(this, 'allTeams', getter)
-    return getter
-  }
-
-  // Paginator will keep fetching the next page until there are no more.
-  paginate (res, records = []) {
-    records = records.concat(res)
-    if (res.meta && this.github.hasNextPage(res)) {
-      return this.github.getNextPage(res).then(next => {
-        return this.paginate(next, records)
-      })
-    } else {
-      return Promise.resolve(records)
     }
   }
 }

--- a/test/lib/plugins/teams.test.js
+++ b/test/lib/plugins/teams.test.js
@@ -9,6 +9,7 @@ describe('Teams', () => {
 
   beforeEach(() => {
     github = {
+      paginate: jest.fn().mockImplementation(() => Promise.resolve()),
       repos: {
         listTeams: jest.fn().mockImplementation(() => Promise.resolve({
           data: [
@@ -20,11 +21,11 @@ describe('Teams', () => {
       },
       teams: {
         addOrUpdateRepo: jest.fn().mockImplementation(() => Promise.resolve()),
-        list: jest.fn().mockImplementation(() => Promise.resolve({
-          data: [
-            { id: 4, slug: 'added' }
-          ]
-        })),
+        list: {
+          endpoint: {
+            merge: jest.fn().mockImplementation(() => {})
+          }
+        },
         removeRepo: jest.fn().mockImplementation(() => Promise.resolve())
       }
     }
@@ -32,6 +33,9 @@ describe('Teams', () => {
 
   describe('sync', () => {
     it('syncs teams', () => {
+      github.paginate.mockReturnValueOnce(Promise.resolve([
+        { id: 4, slug: 'added' }
+      ]))
       const plugin = configure([
         { name: 'unchanged', permission: 'push' },
         { name: 'updated-permission', permission: 'admin' },


### PR DESCRIPTION
Changes
- Instead of using custom pagination, I cleaned it up to use the built-in pagination from Octokit. 

This also fixes the first error found in https://github.com/probot/settings/issues/172