### PR TITLE
fixed team_id field in removing team permissions

### DIFF
--- a/lib/plugins/teams.js
+++ b/lib/plugins/teams.js
@@ -31,9 +31,7 @@ module.exports = class Teams extends Diffable {
   }
 
   remove (existing) {
-    return this.github.teams.removeRepo(
-      Object.assign({ id: existing.id }, this.repo)
-    )
+    return this.github.teams.removeRepo({ team_id: existing.id, ...this.repo })
   }
 
   toParams (existing, attrs) {

--- a/test/lib/plugins/teams.test.js
+++ b/test/lib/plugins/teams.test.js
@@ -62,7 +62,7 @@ describe('Teams', () => {
         expect(github.teams.removeRepo).toHaveBeenCalledWith({
           owner: 'bkeepers',
           repo: 'test',
-          id: 2
+          team_id: 2
         })
 
         expect(github.teams.removeRepo).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Changes
- Changed `id` to `team_id` in the remove repo function call

This should fix the second error in https://github.com/probot/settings/issues/172
