### PR TITLE
docs(issue-templates): added initial bug and feature-request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report
+labels: bug
+---
+
+## Problem Description
+
+### What is actually happening
+
+### What is the expected behavior
+
+### Error output, if available
+
+```
+
+```
+
+## Context
+
+### Are you using the hosted instance of probot/settings or running your own?
+
+### If running your own instance, are you using it with github.com or GitHub Enterprise?
+
+#### Version of probot/settings
+
+#### Version of GitHub Enterprise

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+labels: enhancement
+---
+
+## Prerequisites:
+
+* Is the functionality available in the GitHub UI? If so, please provide a link to information about the feature.
+
+# For awareness, this must be available before probot/settings can manage the setting. However, we are happy to track
+# progress toward API availability in an issue before it is made available.
+* Is the functionality available through the GitHub API? If the functionality is available, please provide links to the
+  API documentation (https://developer.github.com/v3/) as well as the Octokit documentation (https://octokit.github.io/).
+
+* If the functionality is not yet available in the API, it would be helpful if you
+  contacted support (https://support.github.com/) or posted in the Community Forum (https://github.community/). Please
+  include a link to the forum post if you create one or a copy of the response from support.
+
+## New Feature
+
+Please describe the desired new functionality:


### PR DESCRIPTION
im sure these will be tweaked more over time, but hoping this will get some more useful information
to be included up front

closes #174

-----
[View rendered .github/ISSUE_TEMPLATE/bug.md](https://github.com/travi/settings/blob/issue-templates/.github/ISSUE_TEMPLATE/bug.md)
[View rendered .github/ISSUE_TEMPLATE/feature.md](https://github.com/travi/settings/blob/issue-templates/.github/ISSUE_TEMPLATE/feature.md)