### PR TITLE
docs(issue-templates): switch the note to a comment

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -7,8 +7,10 @@ labels: enhancement
 
 * Is the functionality available in the GitHub UI? If so, please provide a link to information about the feature.
 
-# For awareness, this must be available before probot/settings can manage the setting. However, we are happy to track
-# progress toward API availability in an issue before it is made available.
+<!--
+  For awareness, this must be available before probot/settings can manage the setting. However, we are happy to track
+  progress toward API availability in an issue before it is made available.
+-->
 * Is the functionality available through the GitHub API? If the functionality is available, please provide links to the
   API documentation (https://developer.github.com/v3/) as well as the Octokit documentation (https://octokit.github.io/).
 


### PR DESCRIPTION
which is what i originally intended, but accidentally used the wrong comment syntax for markdown

for #174

-----
[View rendered .github/ISSUE_TEMPLATE/feature.md](https://github.com/travi/settings/blob/issue-template-comment/.github/ISSUE_TEMPLATE/feature.md)