### PR TITLE
fix(outside-collaborators): limited the requested list to outside

### DIFF
--- a/lib/plugins/collaborators.js
+++ b/lib/plugins/collaborators.js
@@ -13,17 +13,18 @@ module.exports = class Collaborators extends Diffable {
   }
 
   find () {
-    return this.github.repos.listCollaborators(this.repo).then(res => {
-      return res.data.map(user => {
-        return {
-          // Force all usernames to lowercase to avoid comparison issues.
-          username: user.login.toLowerCase(),
-          permission: (user.permissions.admin && 'admin') ||
-            (user.permissions.push && 'push') ||
-            (user.permissions.pull && 'pull')
-        }
+    return this.github.repos.listCollaborators({ repo: this.repo.repo, owner: this.repo.owner, affiliation: 'direct' })
+      .then(res => {
+        return res.data.map(user => {
+          return {
+            // Force all usernames to lowercase to avoid comparison issues.
+            username: user.login.toLowerCase(),
+            permission: (user.permissions.admin && 'admin') ||
+              (user.permissions.push && 'push') ||
+              (user.permissions.pull && 'pull')
+          }
+        })
       })
-    })
   }
 
   comparator (existing, attrs) {

--- a/test/integration/push.test.js
+++ b/test/integration/push.test.js
@@ -75,7 +75,7 @@ describe('push', function () {
       .get(`/repos/${repository.owner.name}/${repository.name}/contents/${settings.FILE_NAME}`)
       .reply(OK, { content: encodedConfig, name: 'settings.yml', type: 'file' })
     githubScope
-      .get(`/repos/${repository.owner.name}/${repository.name}/collaborators`)
+      .get(`/repos/${repository.owner.name}/${repository.name}/collaborators?affiliation=direct`)
       .reply(
         OK,
         [


### PR DESCRIPTION
since listing all does not align well with the goals of this configuration. `direct` might also be
reasonable option, but this seems like the most likely fit (see
https://developer.github.com/v3/repos/collaborators/#list-collaborators)

BREAKING CHANGE: repositories relying on comparing to the list of all collaborators will no longer
sync the same way, but that use case seems very unlikely. please open an issue to let us know if you
were relying on this behavior

fixes #155