### PR TITLE
fix: return promises in map call to prevent floating promises

### DIFF
--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -15,10 +15,10 @@ module.exports = class Branches {
           const params = Object.assign(this.repo, { branch: branch.name })
 
           if (this.isEmpty(branch.protection)) {
-            this.github.repos.removeBranchProtection(params)
+            return this.github.repos.removeBranchProtection(params)
           } else {
             Object.assign(params, branch.protection, { headers: previewHeaders })
-            this.github.repos.updateBranchProtection(params)
+            return this.github.repos.updateBranchProtection(params)
           }
         })
     )

--- a/test/unit/lib/plugins/branches.test.js
+++ b/test/unit/lib/plugins/branches.test.js
@@ -11,8 +11,8 @@ describe('Branches', () => {
   beforeEach(() => {
     github = {
       repos: {
-        updateBranchProtection: jest.fn().mockImplementation(() => Promise.resolve()),
-        removeBranchProtection: jest.fn().mockImplementation(() => Promise.resolve())
+        updateBranchProtection: jest.fn().mockImplementation(() => Promise.resolve('updateBranchProtection')),
+        removeBranchProtection: jest.fn().mockImplementation(() => Promise.resolve('removeBranchProtection'))
       }
     }
   })
@@ -174,6 +174,35 @@ describe('Branches', () => {
             headers: { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
           })
         })
+      })
+    })
+  })
+
+  describe('return values', () => {
+    it('returns updateBranchProtection Promise', () => {
+      const plugin = configure(
+        [{
+          name: 'master',
+          protection: { enforce_admins: true }
+        }]
+      )
+
+      return plugin.sync().then(result => {
+        expect(result.length).toBe(1)
+        expect(result[0]).toBe('updateBranchProtection')
+      })
+    })
+    it('returns removeBranchProtection Promise', () => {
+      const plugin = configure(
+        [{
+          name: 'master',
+          protection: null
+        }]
+      )
+
+      return plugin.sync().then(result => {
+        expect(result.length).toBe(1)
+        expect(result[0]).toBe('removeBranchProtection')
       })
     })
   })


### PR DESCRIPTION
The branches settings have a subtle error where a map call doesn't actually map into anything but rather creates floating Promises. This PR returns the Promise so that promise rejections can be handled properly in calling code