### PR TITLE
docs(permissions): documented that R&W is necessary for organization members

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,6 +14,10 @@ This plugin requires these **Permissions & events** for the GitHub Integration:
 - Single file: **Read & Write**
   - Path: `.github/settings.yml`
 
+### Organization Permissions
+
+- Members: **Read & Write**
+
 ### Events
 
 - Push


### PR DESCRIPTION
this is needed for managing team access to a repository

-----
[View rendered docs/deploy.md](https://github.com/probot/settings/blob/org-members/docs/deploy.md)