### PR TITLE
Document additional branch protection option in README (required_linear_history)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ branches:
         contexts: []
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
+      # Prevent merge commits from being pushed to matching branches
+      required_linear_history: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
       restrictions:
         apps: []


### PR DESCRIPTION
This proposes a tweak to the README so that folks know that `required_linear_history` is available without resorting to  issue spelunking.

## Related Issues

This has been requested at least twice:

* #220 (this may have been related to the enhancement, to be fair)
* #292 

## Notes

I'm open to this turning into an "Add additional supported options to README" PR.