### PR TITLE
fix: `octokit.repos.replaceTopics` is now `octokit.repos.replaceAllTopics`

### DIFF
--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -15,7 +15,7 @@ module.exports = class Branches {
           const params = Object.assign(this.repo, { branch: branch.name })
 
           if (this.isEmpty(branch.protection)) {
-            return this.github.repos.removeBranchProtection(params)
+            return this.github.repos.deleteBranchProtection(params)
           } else {
             Object.assign(params, branch.protection, { headers: previewHeaders })
             return this.github.repos.updateBranchProtection(params)

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -51,7 +51,7 @@ module.exports = class Repository {
     return this.github.repos.update(this.settings)
       .then(() => {
         if (this.topics) {
-          return this.github.repos.replaceTopics({
+          return this.github.repos.replaceAllTopics({
             owner: this.settings.owner,
             repo: this.settings.repo,
             names: this.topics.split(/\s*,\s*/),

--- a/test/unit/lib/plugins/branches.test.js
+++ b/test/unit/lib/plugins/branches.test.js
@@ -12,7 +12,7 @@ describe('Branches', () => {
     github = {
       repos: {
         updateBranchProtection: jest.fn().mockImplementation(() => Promise.resolve('updateBranchProtection')),
-        removeBranchProtection: jest.fn().mockImplementation(() => Promise.resolve('removeBranchProtection'))
+        deleteBranchProtection: jest.fn().mockImplementation(() => Promise.resolve('deleteBranchProtection'))
       }
     }
   })
@@ -64,7 +64,7 @@ describe('Branches', () => {
 
         return plugin.sync().then(() => {
           expect(github.repos.updateBranchProtection).not.toHaveBeenCalled()
-          expect(github.repos.removeBranchProtection).toHaveBeenCalledWith({
+          expect(github.repos.deleteBranchProtection).toHaveBeenCalledWith({
             owner: 'bkeepers',
             repo: 'test',
             branch: 'master'
@@ -84,7 +84,7 @@ describe('Branches', () => {
 
         return plugin.sync().then(() => {
           expect(github.repos.updateBranchProtection).not.toHaveBeenCalled()
-          expect(github.repos.removeBranchProtection).toHaveBeenCalledWith({
+          expect(github.repos.deleteBranchProtection).toHaveBeenCalledWith({
             owner: 'bkeepers',
             repo: 'test',
             branch: 'master'
@@ -104,7 +104,7 @@ describe('Branches', () => {
 
         return plugin.sync().then(() => {
           expect(github.repos.updateBranchProtection).not.toHaveBeenCalled()
-          expect(github.repos.removeBranchProtection).toHaveBeenCalledWith({
+          expect(github.repos.deleteBranchProtection).toHaveBeenCalledWith({
             owner: 'bkeepers',
             repo: 'test',
             branch: 'master'
@@ -124,7 +124,7 @@ describe('Branches', () => {
 
         return plugin.sync().then(() => {
           expect(github.repos.updateBranchProtection).not.toHaveBeenCalled()
-          expect(github.repos.removeBranchProtection).toHaveBeenCalledWith({
+          expect(github.repos.deleteBranchProtection).toHaveBeenCalledWith({
             owner: 'bkeepers',
             repo: 'test',
             branch: 'master'
@@ -143,7 +143,7 @@ describe('Branches', () => {
 
         return plugin.sync().then(() => {
           expect(github.repos.updateBranchProtection).not.toHaveBeenCalled()
-          expect(github.repos.removeBranchProtection).not.toHaveBeenCalled()
+          expect(github.repos.deleteBranchProtection).not.toHaveBeenCalled()
         })
       })
     })
@@ -192,7 +192,7 @@ describe('Branches', () => {
         expect(result[0]).toBe('updateBranchProtection')
       })
     })
-    it('returns removeBranchProtection Promise', () => {
+    it('returns deleteBranchProtection Promise', () => {
       const plugin = configure(
         [{
           name: 'master',
@@ -202,7 +202,7 @@ describe('Branches', () => {
 
       return plugin.sync().then(result => {
         expect(result.length).toBe(1)
-        expect(result[0]).toBe('removeBranchProtection')
+        expect(result[0]).toBe('deleteBranchProtection')
       })
     })
   })

--- a/test/unit/lib/plugins/repository.test.js
+++ b/test/unit/lib/plugins/repository.test.js
@@ -12,7 +12,7 @@ describe('Repository', () => {
       repos: {
         get: jest.fn().mockImplementation(() => Promise.resolve({})),
         update: jest.fn().mockImplementation(() => Promise.resolve()),
-        replaceTopics: jest.fn().mockImplementation(() => Promise.resolve()),
+        replaceAllTopics: jest.fn().mockImplementation(() => Promise.resolve()),
         enableVulnerabilityAlerts: jest.fn().mockImplementation(() => Promise.resolve()),
         disableVulnerabilityAlerts: jest.fn().mockImplementation(() => Promise.resolve()),
         enableAutomatedSecurityFixes: jest.fn().mockImplementation(() => Promise.resolve()),
@@ -58,7 +58,7 @@ describe('Repository', () => {
       })
 
       return plugin.sync().then(() => {
-        expect(github.repos.replaceTopics).toHaveBeenCalledWith({
+        expect(github.repos.replaceAllTopics).toHaveBeenCalledWith({
           owner: 'bkeepers',
           repo: 'test',
           names: ['foo', 'bar'],


### PR DESCRIPTION
we should try to cover more code with integration tests without mocking methods that no longer exist @travi

I went through the unit tests and compared the mocks to the changelogs at https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/v4.0.0, I think we should be good now