### PR TITLE
Fix renaming of labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ labels:
     color: '#336699'
     description: New functionality.
 
-  - name: first-timers-only
-    # include the old name to rename an existing label
-    oldname: Help Wanted
+  - name: Help Wanted
+    # Provide a new name to rename an existing label
+    new_name: first-timers-only
 
 # Milestones: define milestones for Issues and Pull Requests
 milestones:

--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -24,19 +24,22 @@ module.exports = class Labels extends Diffable {
   }
 
   comparator (existing, attrs) {
-    return existing.name === attrs.name || existing.name === attrs.oldname || existing.name === attrs.current_name
+    return existing.name === attrs.name
   }
 
   changed (existing, attrs) {
-    return attrs.oldname === existing.name || existing.color !== attrs.color || existing.description !== attrs.description
+    return 'new_name' in attrs || existing.color !== attrs.color || existing.description !== attrs.description
   }
 
   update (existing, attrs) {
     // Our settings file uses oldname for renaming labels,
     // however octokit/rest 16.30.1 uses the current_name attribute.
     // Future versions of octokit/rest will need name and new_name attrs.
-    attrs.current_name = attrs.oldname || attrs.name
-    delete attrs.oldname
+    if ('oldname' in attrs) {
+      attrs.new_name = attrs.name
+      attrs.name = attrs.oldname
+      delete attrs.oldname
+    }
     return this.github.issues.updateLabel(this.wrapAttrs(attrs))
   }
 

--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -32,14 +32,6 @@ module.exports = class Labels extends Diffable {
   }
 
   update (existing, attrs) {
-    // Our settings file uses oldname for renaming labels,
-    // however octokit/rest 16.30.1 uses the current_name attribute.
-    // Future versions of octokit/rest will need name and new_name attrs.
-    if ('oldname' in attrs) {
-      attrs.new_name = attrs.name
-      attrs.name = attrs.oldname
-      delete attrs.oldname
-    }
     return this.github.issues.updateLabel(this.wrapAttrs(attrs))
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4054,7 +4054,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handlebars": {
       "version": "4.7.6",
@@ -4634,6 +4635,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -6695,6 +6697,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -6709,6 +6712,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -8384,7 +8388,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "side-channel": {
       "version": "1.0.3",

--- a/test/unit/lib/plugins/labels.test.js
+++ b/test/unit/lib/plugins/labels.test.js
@@ -35,7 +35,7 @@ describe('Labels', () => {
 
       const plugin = configure([
         { name: 'no-change', color: 'FF0000', description: '' },
-        { name: 'new-name', oldname: 'update-me', color: 'FFFFFF', description: '' },
+        { new_name: 'new-name', name: 'update-me', color: 'FFFFFF', description: '' },
         { name: 'new-color', color: '999999', description: '' },
         { name: 'new-description', color: '#000000', description: 'Hello world' },
         { name: 'added' }
@@ -59,8 +59,8 @@ describe('Labels', () => {
         expect(github.issues.updateLabel).toHaveBeenCalledWith({
           owner: 'bkeepers',
           repo: 'test',
-          current_name: 'update-me',
-          name: 'new-name',
+          name: 'update-me',
+          new_name: 'new-name',
           color: 'FFFFFF',
           description: '',
           headers: { accept: 'application/vnd.github.symmetra-preview+json' }
@@ -69,7 +69,6 @@ describe('Labels', () => {
         expect(github.issues.updateLabel).toHaveBeenCalledWith({
           owner: 'bkeepers',
           repo: 'test',
-          current_name: 'new-color',
           name: 'new-color',
           color: '999999',
           description: '',
@@ -79,7 +78,6 @@ describe('Labels', () => {
         expect(github.issues.updateLabel).toHaveBeenCalledWith({
           owner: 'bkeepers',
           repo: 'test',
-          current_name: 'new-description',
           name: 'new-description',
           color: '000000',
           description: 'Hello world',


### PR DESCRIPTION
Supports the current API for renaming labels, which expects the following keys in `settings.yml`:

```yaml
labels:
  - name: the old/current name of an existing label we want to change
    new_name: the updated label name
```

Details of this API change are documented here: https://github.com/probot/settings/pull/143#issuecomment-539307068

- Fixes #407 
- Fixes #167 in a dumb way — by passing the attributes needed by the API. The previous `oldname` attribute is no longer supported.


-----
[View rendered README.md](https://github.com/elstudio/probot-settings/blob/rename-labels/README.md)