### PR TITLE
Introduce esbuild so we have a CommonJS export

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -19,4 +19,8 @@ jobs:
           node-version: 16
           cache: npm
       - run: npm ci
+      - name: Check that the latest CommonJS target has been checked in
+        run: |
+          npm run build
+          git diff-index --quiet HEAD
       - run: npm test

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -1,0 +1,488 @@
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target, mod));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/deepmerge/dist/cjs.js
+var require_cjs = __commonJS({
+  "node_modules/deepmerge/dist/cjs.js"(exports, module2) {
+    "use strict";
+    var isMergeableObject = function isMergeableObject2(value) {
+      return isNonNullObject(value) && !isSpecial(value);
+    };
+    function isNonNullObject(value) {
+      return !!value && typeof value === "object";
+    }
+    function isSpecial(value) {
+      var stringValue = Object.prototype.toString.call(value);
+      return stringValue === "[object RegExp]" || stringValue === "[object Date]" || isReactElement(value);
+    }
+    var canUseSymbol = typeof Symbol === "function" && Symbol.for;
+    var REACT_ELEMENT_TYPE = canUseSymbol ? Symbol.for("react.element") : 60103;
+    function isReactElement(value) {
+      return value.$$typeof === REACT_ELEMENT_TYPE;
+    }
+    function emptyTarget(val) {
+      return Array.isArray(val) ? [] : {};
+    }
+    function cloneUnlessOtherwiseSpecified(value, options) {
+      return options.clone !== false && options.isMergeableObject(value) ? deepmerge(emptyTarget(value), value, options) : value;
+    }
+    function defaultArrayMerge(target, source, options) {
+      return target.concat(source).map(function(element) {
+        return cloneUnlessOtherwiseSpecified(element, options);
+      });
+    }
+    function getMergeFunction(key, options) {
+      if (!options.customMerge) {
+        return deepmerge;
+      }
+      var customMerge = options.customMerge(key);
+      return typeof customMerge === "function" ? customMerge : deepmerge;
+    }
+    function getEnumerableOwnPropertySymbols(target) {
+      return Object.getOwnPropertySymbols ? Object.getOwnPropertySymbols(target).filter(function(symbol) {
+        return target.propertyIsEnumerable(symbol);
+      }) : [];
+    }
+    function getKeys(target) {
+      return Object.keys(target).concat(getEnumerableOwnPropertySymbols(target));
+    }
+    function propertyIsOnObject(object, property) {
+      try {
+        return property in object;
+      } catch (_) {
+        return false;
+      }
+    }
+    function propertyIsUnsafe(target, key) {
+      return propertyIsOnObject(target, key) && !(Object.hasOwnProperty.call(target, key) && Object.propertyIsEnumerable.call(target, key));
+    }
+    function mergeObject(target, source, options) {
+      var destination = {};
+      if (options.isMergeableObject(target)) {
+        getKeys(target).forEach(function(key) {
+          destination[key] = cloneUnlessOtherwiseSpecified(target[key], options);
+        });
+      }
+      getKeys(source).forEach(function(key) {
+        if (propertyIsUnsafe(target, key)) {
+          return;
+        }
+        if (propertyIsOnObject(target, key) && options.isMergeableObject(source[key])) {
+          destination[key] = getMergeFunction(key, options)(target[key], source[key], options);
+        } else {
+          destination[key] = cloneUnlessOtherwiseSpecified(source[key], options);
+        }
+      });
+      return destination;
+    }
+    function deepmerge(target, source, options) {
+      options = options || {};
+      options.arrayMerge = options.arrayMerge || defaultArrayMerge;
+      options.isMergeableObject = options.isMergeableObject || isMergeableObject;
+      options.cloneUnlessOtherwiseSpecified = cloneUnlessOtherwiseSpecified;
+      var sourceIsArray = Array.isArray(source);
+      var targetIsArray = Array.isArray(target);
+      var sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;
+      if (!sourceAndTargetTypesMatch) {
+        return cloneUnlessOtherwiseSpecified(source, options);
+      } else if (sourceIsArray) {
+        return options.arrayMerge(target, source, options);
+      } else {
+        return mergeObject(target, source, options);
+      }
+    }
+    deepmerge.all = function deepmergeAll(array, options) {
+      if (!Array.isArray(array)) {
+        throw new Error("first argument should be an array");
+      }
+      return array.reduce(function(prev, next) {
+        return deepmerge(prev, next, options);
+      }, {});
+    };
+    var deepmerge_1 = deepmerge;
+    module2.exports = deepmerge_1;
+  }
+});
+
+// index.js
+var settings_exports = {};
+__export(settings_exports, {
+  default: () => settings_default
+});
+module.exports = __toCommonJS(settings_exports);
+
+// lib/mergeArrayByName.js
+var import_deepmerge = __toESM(require_cjs(), 1);
+function findMatchingIndex(sourceItem, target) {
+  if (Object.prototype.hasOwnProperty.call(sourceItem, "name")) {
+    return target.filter((targetItem) => Object.prototype.hasOwnProperty.call(targetItem, "name")).findIndex((targetItem) => sourceItem.name === targetItem.name);
+  }
+}
+function mergeByName(target, source, options) {
+  const destination = target.slice();
+  source.forEach((sourceItem) => {
+    const matchingIndex = findMatchingIndex(sourceItem, target);
+    if (matchingIndex > -1) {
+      destination[matchingIndex] = (0, import_deepmerge.default)(target[matchingIndex], sourceItem, options);
+    } else {
+      destination.push(sourceItem);
+    }
+  });
+  return destination;
+}
+
+// lib/plugins/repository.js
+var enableAutomatedSecurityFixes = ({ github, settings, enabled }) => {
+  if (enabled === void 0) {
+    return Promise.resolve();
+  }
+  const args = {
+    owner: settings.owner,
+    repo: settings.repo,
+    mediaType: {
+      previews: ["london"]
+    }
+  };
+  const methodName = enabled ? "enableAutomatedSecurityFixes" : "disableAutomatedSecurityFixes";
+  return github.repos[methodName](args);
+};
+var enableVulnerabilityAlerts = ({ github, settings, enabled }) => {
+  if (enabled === void 0) {
+    return Promise.resolve();
+  }
+  const args = {
+    owner: settings.owner,
+    repo: settings.repo,
+    mediaType: {
+      previews: ["dorian"]
+    }
+  };
+  const methodName = enabled ? "enableVulnerabilityAlerts" : "disableVulnerabilityAlerts";
+  return github.repos[methodName](args);
+};
+var Repository = class {
+  constructor(github, repo, settings) {
+    this.github = github;
+    this.settings = Object.assign({ mediaType: { previews: ["baptiste"] } }, settings, repo);
+    this.topics = this.settings.topics;
+    delete this.settings.topics;
+    this.enableVulnerabilityAlerts = this.settings.enable_vulnerability_alerts;
+    delete this.settings.enable_vulnerability_alerts;
+    this.enableAutomatedSecurityFixes = this.settings.enable_automated_security_fixes;
+    delete this.settings.enable_automated_security_fixes;
+  }
+  sync() {
+    this.settings.name = this.settings.name || this.settings.repo;
+    return this.github.repos.update(this.settings).then(() => {
+      if (this.topics) {
+        return this.github.repos.replaceAllTopics({
+          owner: this.settings.owner,
+          repo: this.settings.repo,
+          names: this.topics.split(/\s*,\s*/),
+          mediaType: {
+            previews: ["mercy"]
+          }
+        });
+      }
+    }).then(() => enableVulnerabilityAlerts({ enabled: this.enableVulnerabilityAlerts, ...this })).then(() => enableAutomatedSecurityFixes({ enabled: this.enableAutomatedSecurityFixes, ...this }));
+  }
+};
+
+// lib/plugins/diffable.js
+var Diffable = class {
+  constructor(github, repo, entries) {
+    this.github = github;
+    this.repo = repo;
+    this.entries = entries;
+  }
+  sync() {
+    if (this.entries) {
+      return this.find().then((existingRecords) => {
+        const changes = [];
+        this.entries.forEach((attrs) => {
+          const existing = existingRecords.find((record) => {
+            return this.comparator(record, attrs);
+          });
+          if (!existing) {
+            changes.push(this.add(attrs));
+          } else if (this.changed(existing, attrs)) {
+            changes.push(this.update(existing, attrs));
+          }
+        });
+        existingRecords.forEach((x) => {
+          if (!this.entries.find((y) => this.comparator(x, y))) {
+            changes.push(this.remove(x));
+          }
+        });
+        return Promise.all(changes);
+      });
+    }
+  }
+};
+
+// lib/plugins/labels.js
+var previewHeaders = { accept: "application/vnd.github.symmetra-preview+json" };
+var Labels = class extends Diffable {
+  constructor(...args) {
+    super(...args);
+    if (this.entries) {
+      this.entries.forEach((label) => {
+        if (label.color) {
+          label.color = String(label.color).replace(/^#/, "");
+          if (label.color.length < 6) {
+            label.color.padStart(6, "0");
+          }
+        }
+      });
+    }
+  }
+  find() {
+    const options = this.github.issues.listLabelsForRepo.endpoint.merge(this.wrapAttrs({ per_page: 100 }));
+    return this.github.paginate(options);
+  }
+  comparator(existing, attrs) {
+    return existing.name === attrs.name;
+  }
+  changed(existing, attrs) {
+    return "new_name" in attrs || existing.color !== attrs.color || existing.description !== attrs.description;
+  }
+  update(existing, attrs) {
+    return this.github.issues.updateLabel(this.wrapAttrs(attrs));
+  }
+  add(attrs) {
+    return this.github.issues.createLabel(this.wrapAttrs(attrs));
+  }
+  remove(existing) {
+    return this.github.issues.deleteLabel(this.wrapAttrs({ name: existing.name }));
+  }
+  wrapAttrs(attrs) {
+    return Object.assign({}, attrs, this.repo, { headers: previewHeaders });
+  }
+};
+
+// lib/plugins/collaborators.js
+var Collaborators = class extends Diffable {
+  constructor(...args) {
+    super(...args);
+    if (this.entries) {
+      this.entries.forEach((collaborator) => {
+        collaborator.username = collaborator.username.toLowerCase();
+      });
+    }
+  }
+  find() {
+    return this.github.repos.listCollaborators({ repo: this.repo.repo, owner: this.repo.owner, affiliation: "direct" }).then((res) => {
+      return res.data.map((user) => {
+        return {
+          username: user.login.toLowerCase(),
+          permission: user.permissions.admin && "admin" || user.permissions.push && "push" || user.permissions.pull && "pull"
+        };
+      });
+    });
+  }
+  comparator(existing, attrs) {
+    return existing.username === attrs.username;
+  }
+  changed(existing, attrs) {
+    return existing.permission !== attrs.permission;
+  }
+  update(existing, attrs) {
+    return this.add(attrs);
+  }
+  add(attrs) {
+    return this.github.repos.addCollaborator(Object.assign({}, attrs, this.repo));
+  }
+  remove(existing) {
+    return this.github.repos.removeCollaborator(Object.assign({ username: existing.username }, this.repo));
+  }
+};
+
+// lib/plugins/teams.js
+var teamRepoEndpoint = "/teams/:team_id/repos/:owner/:repo";
+var Teams = class extends Diffable {
+  find() {
+    return this.github.repos.listTeams(this.repo).then((res) => res.data);
+  }
+  comparator(existing, attrs) {
+    return existing.slug === attrs.name;
+  }
+  changed(existing, attrs) {
+    return existing.permission !== attrs.permission;
+  }
+  update(existing, attrs) {
+    return this.github.request(`PUT ${teamRepoEndpoint}`, this.toParams(existing, attrs));
+  }
+  async add(attrs) {
+    const { data: existing } = await this.github.request("GET /orgs/:org/teams/:team_slug", {
+      org: this.repo.owner,
+      team_slug: attrs.name
+    });
+    return this.github.request(`PUT ${teamRepoEndpoint}`, this.toParams(existing, attrs));
+  }
+  remove(existing) {
+    return this.github.request(`DELETE ${teamRepoEndpoint}`, {
+      team_id: existing.id,
+      ...this.repo,
+      org: this.repo.owner
+    });
+  }
+  toParams(existing, attrs) {
+    return {
+      team_id: existing.id,
+      owner: this.repo.owner,
+      repo: this.repo.repo,
+      org: this.repo.owner,
+      permission: attrs.permission
+    };
+  }
+};
+
+// lib/plugins/milestones.js
+var Milestones = class extends Diffable {
+  constructor(...args) {
+    super(...args);
+    if (this.entries) {
+      this.entries.forEach((milestone) => {
+        if (milestone.due_on) {
+          delete milestone.due_on;
+        }
+      });
+    }
+  }
+  find() {
+    const options = this.github.issues.listMilestones.endpoint.merge(Object.assign({ per_page: 100, state: "all" }, this.repo));
+    return this.github.paginate(options);
+  }
+  comparator(existing, attrs) {
+    return existing.title === attrs.title;
+  }
+  changed(existing, attrs) {
+    return existing.description !== attrs.description || existing.state !== attrs.state;
+  }
+  update(existing, attrs) {
+    const { owner, repo } = this.repo;
+    return this.github.issues.updateMilestone(Object.assign({ milestone_number: existing.number }, attrs, { owner, repo }));
+  }
+  add(attrs) {
+    const { owner, repo } = this.repo;
+    return this.github.issues.createMilestone(Object.assign({}, attrs, { owner, repo }));
+  }
+  remove(existing) {
+    const { owner, repo } = this.repo;
+    return this.github.issues.deleteMilestone(Object.assign({ milestone_number: existing.number }, { owner, repo }));
+  }
+};
+
+// lib/plugins/branches.js
+var previewHeaders2 = {
+  accept: "application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json"
+};
+var Branches = class {
+  constructor(github, repo, settings) {
+    this.github = github;
+    this.repo = repo;
+    this.branches = settings;
+  }
+  sync() {
+    return Promise.all(this.branches.filter((branch) => branch.protection !== void 0).map((branch) => {
+      const params = Object.assign(this.repo, { branch: branch.name });
+      if (this.isEmpty(branch.protection)) {
+        return this.github.repos.deleteBranchProtection(params);
+      } else {
+        Object.assign(params, branch.protection, { headers: previewHeaders2 });
+        return this.github.repos.updateBranchProtection(params);
+      }
+    }));
+  }
+  isEmpty(maybeEmpty) {
+    return maybeEmpty === null || Object.keys(maybeEmpty).length === 0;
+  }
+};
+
+// lib/settings.js
+var Settings = class {
+  static sync(github, repo, config) {
+    return new Settings(github, repo, config).update();
+  }
+  constructor(github, repo, config) {
+    this.github = github;
+    this.repo = repo;
+    this.config = config;
+  }
+  update() {
+    return Promise.all(Object.entries(this.config).map(([section, config]) => {
+      const debug = { repo: this.repo };
+      debug[section] = config;
+      const Plugin = Settings.PLUGINS[section];
+      return new Plugin(this.github, this.repo, config).sync();
+    }));
+  }
+};
+Settings.FILE_NAME = ".github/settings.yml";
+Settings.PLUGINS = {
+  repository: Repository,
+  labels: Labels,
+  collaborators: Collaborators,
+  teams: Teams,
+  milestones: Milestones,
+  branches: Branches
+};
+
+// index.js
+var settings_default = (robot, _, Settings2 = Settings) => {
+  async function syncSettings(context, repo = context.repo()) {
+    const config = await context.config("settings.yml", {}, { arrayMerge: mergeByName });
+    return Settings2.sync(context.octokit, repo, config);
+  }
+  robot.on("push", async (context) => {
+    const { payload } = context;
+    const { repository } = payload;
+    const defaultBranch = payload.ref === "refs/heads/" + repository.default_branch;
+    if (!defaultBranch) {
+      robot.log.debug("Not working on the default branch, returning...");
+      return;
+    }
+    const settingsModified = payload.commits.find((commit) => {
+      return commit.added.includes(Settings2.FILE_NAME) || commit.modified.includes(Settings2.FILE_NAME);
+    });
+    if (!settingsModified) {
+      robot.log.debug(`No changes in '${Settings2.FILE_NAME}' detected, returning...`);
+      return;
+    }
+    return syncSettings(context);
+  });
+  robot.on("repository.edited", async (context) => {
+    const { payload } = context;
+    const { changes, repository } = payload;
+    if (!Object.prototype.hasOwnProperty.call(changes, "default_branch")) {
+      robot.log.debug("Repository configuration was edited but the default branch was not affected, returning...");
+      return;
+    }
+    robot.log.debug(`Default branch changed from '${changes.default_branch.from}' to '${repository.default_branch}'`);
+    return syncSettings(context);
+  });
+  robot.on("repository.created", async (context) => {
+    return syncSettings(context);
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@travi/any": "^2.0.20",
         "check-engine": "^1.10.1",
+        "esbuild": "^0.14.38",
         "http-status-codes": "^2.2.0",
         "jest": "^28.0.3",
         "jest-when": "^3.5.1",
@@ -4123,6 +4124,361 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.38.tgz",
+      "integrity": "sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "esbuild-android-64": "0.14.38",
+        "esbuild-android-arm64": "0.14.38",
+        "esbuild-darwin-64": "0.14.38",
+        "esbuild-darwin-arm64": "0.14.38",
+        "esbuild-freebsd-64": "0.14.38",
+        "esbuild-freebsd-arm64": "0.14.38",
+        "esbuild-linux-32": "0.14.38",
+        "esbuild-linux-64": "0.14.38",
+        "esbuild-linux-arm": "0.14.38",
+        "esbuild-linux-arm64": "0.14.38",
+        "esbuild-linux-mips64le": "0.14.38",
+        "esbuild-linux-ppc64le": "0.14.38",
+        "esbuild-linux-riscv64": "0.14.38",
+        "esbuild-linux-s390x": "0.14.38",
+        "esbuild-netbsd-64": "0.14.38",
+        "esbuild-openbsd-64": "0.14.38",
+        "esbuild-sunos-64": "0.14.38",
+        "esbuild-windows-32": "0.14.38",
+        "esbuild-windows-64": "0.14.38",
+        "esbuild-windows-arm64": "0.14.38"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.38.tgz",
+      "integrity": "sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.38.tgz",
+      "integrity": "sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.38.tgz",
+      "integrity": "sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.38.tgz",
+      "integrity": "sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.38.tgz",
+      "integrity": "sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.38.tgz",
+      "integrity": "sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.38.tgz",
+      "integrity": "sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.38.tgz",
+      "integrity": "sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.38.tgz",
+      "integrity": "sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.38.tgz",
+      "integrity": "sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.38.tgz",
+      "integrity": "sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.38.tgz",
+      "integrity": "sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.38.tgz",
+      "integrity": "sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.38.tgz",
+      "integrity": "sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.38.tgz",
+      "integrity": "sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.38.tgz",
+      "integrity": "sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.38.tgz",
+      "integrity": "sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.38.tgz",
+      "integrity": "sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.38.tgz",
+      "integrity": "sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.38.tgz",
+      "integrity": "sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/escalade": {
@@ -16941,6 +17297,174 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "esbuild": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.38.tgz",
+      "integrity": "sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==",
+      "dev": true,
+      "requires": {
+        "esbuild-android-64": "0.14.38",
+        "esbuild-android-arm64": "0.14.38",
+        "esbuild-darwin-64": "0.14.38",
+        "esbuild-darwin-arm64": "0.14.38",
+        "esbuild-freebsd-64": "0.14.38",
+        "esbuild-freebsd-arm64": "0.14.38",
+        "esbuild-linux-32": "0.14.38",
+        "esbuild-linux-64": "0.14.38",
+        "esbuild-linux-arm": "0.14.38",
+        "esbuild-linux-arm64": "0.14.38",
+        "esbuild-linux-mips64le": "0.14.38",
+        "esbuild-linux-ppc64le": "0.14.38",
+        "esbuild-linux-riscv64": "0.14.38",
+        "esbuild-linux-s390x": "0.14.38",
+        "esbuild-netbsd-64": "0.14.38",
+        "esbuild-openbsd-64": "0.14.38",
+        "esbuild-sunos-64": "0.14.38",
+        "esbuild-windows-32": "0.14.38",
+        "esbuild-windows-64": "0.14.38",
+        "esbuild-windows-arm64": "0.14.38"
+      }
+    },
+    "esbuild-android-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.38.tgz",
+      "integrity": "sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-android-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.38.tgz",
+      "integrity": "sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.38.tgz",
+      "integrity": "sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.38.tgz",
+      "integrity": "sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.38.tgz",
+      "integrity": "sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.38.tgz",
+      "integrity": "sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.38.tgz",
+      "integrity": "sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.38.tgz",
+      "integrity": "sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.38.tgz",
+      "integrity": "sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.38.tgz",
+      "integrity": "sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.38.tgz",
+      "integrity": "sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.38.tgz",
+      "integrity": "sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.38.tgz",
+      "integrity": "sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.38.tgz",
+      "integrity": "sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.38.tgz",
+      "integrity": "sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.38.tgz",
+      "integrity": "sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.38.tgz",
+      "integrity": "sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.38.tgz",
+      "integrity": "sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.38.tgz",
+      "integrity": "sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.38.tgz",
+      "integrity": "sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==",
+      "dev": true,
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "",
   "repository": "github:probot/settings",
   "type": "module",
-  "main": "index.js",
+  "main": "dist/index.cjs",
   "scripts": {
+    "build": "npx esbuild index.js --bundle --outfile=dist/index.cjs --format=cjs",
     "dev": "nodemon",
     "start": "probot run ./index.js",
     "test": "npm-run-all --print-label --parallel lint:* --parallel test:*",
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@travi/any": "^2.0.20",
     "check-engine": "^1.10.1",
+    "esbuild": "^0.14.38",
     "http-status-codes": "^2.2.0",
     "jest": "^28.0.3",
     "jest-when": "^3.5.1",


### PR DESCRIPTION
It turns out that #569 left people unable to load the app, since Probot seems to assume your code is CommonJS.

This is one possible fix. I would prefer if if there's a way we can figure out to have Probot be happy to load our ESM code directly, but I can't see it yet.