### PR TITLE
fix: process branches after everything else

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -10,15 +10,25 @@ class Settings {
   }
 
   update () {
-    return Promise.all(
-      Object.entries(this.config).map(([section, config]) => {
-        const debug = { repo: this.repo }
-        debug[section] = config
+    const { branches, ...rest } = this.config
 
-        const Plugin = Settings.PLUGINS[section]
-        return new Plugin(this.github, this.repo, config).sync()
+    return Promise.all(
+      Object.entries(rest).map(([section, config]) => {
+        return this.processSection(section, config)
       })
-    )
+    ).then(() => {
+      if (branches) {
+        return this.processSection('branches', branches)
+      }
+    })
+  }
+
+  processSection (section, config) {
+    const debug = { repo: this.repo }
+    debug[section] = config
+
+    const Plugin = Settings.PLUGINS[section]
+    return new Plugin(this.github, this.repo, config).sync()
   }
 }
 


### PR DESCRIPTION
This addresses #490.

Since the `Promise.all()` creates a race condition we have random teams not being added to the branch protection rule. To get around this, `branches` should be processed after everything else.